### PR TITLE
Feat/cs/fix command mode regex

### DIFF
--- a/src/communication/handlers/command.rs
+++ b/src/communication/handlers/command.rs
@@ -16,6 +16,7 @@ impl CommandHandler {
     fn return_to_prev_state(&mut self, window: &mut MainWindow) -> Result<()> {
         // If we are in auxiliary mode, go back to that, otherwise go to normal mode
         window.update_input_type(window.previous_input_type)?;
+        window.write_status()?;
         window.config.delete_func = None;
         window.set_cli_cursor(None)?;
         window.output.flush()?;

--- a/src/communication/handlers/parser.rs
+++ b/src/communication/handlers/parser.rs
@@ -122,6 +122,7 @@ impl ProcessorMethods for ParserHandler {
         window.set_cli_cursor(None)?;
         window.config.stream_type = window.config.previous_stream_type;
         window.config.parser_state = ParserState::Disabled;
+        window.config.current_status = None;
         window.redraw()?;
         Ok(())
     }
@@ -263,7 +264,8 @@ impl HanderMethods for ParserHandler {
                         window.reset_output()?;
 
                         // Write the new parser status to the command line
-                        window.write_to_command_line(&self.status)?;
+                        window.config.current_status = Some(self.status.to_owned());
+                        window.write_status()?;
                     }
                     None => {
                         self.mc_handler.recieve_input(window, key)?;


### PR DESCRIPTION
- Fix and test for #66 
- Add `current_status` app state variable to contain status messages
- Use `current_status` in relevant handlers
- Use `update_input_type()` inside of `set_command_mode()`