### PR TITLE
Feat/cs/use system config dir

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,15 +26,25 @@ This folder contains the documentation on how to interact with Logria programmat
 
 ### Directory Configuration
 
-By default, Logria will create `~/.logria/` to store parsers, sessions, and an input history tape in. If you want to specify a different path, either set `LOGRIA_ROOT` to replace the `.logria` directory or set `LOGRIA_USER_HOME` to move the directory away from the default `$HOME`. Setting both means the app looks in `$LOGRIA_USER_HOME/$LOGRIA_ROOT`.
+By default, Logria will create a `/Logria/` directory to store [patterns](patterns.md), [sessions](sessions.md), and an input history tape in. The loction is [platform dependent](https://docs.rs/dirs/latest/dirs/fn.config_dir.html).
+
+#### Platform-Specific Directory Locations
+
+| Platform | Value | Example |
+| --- | --- | --- |
+| Linux   | `$XDG_DATA_HOME` or `$HOME/.config` | `~/.config/Logria` |
+| macOS   | `$HOME/Library/Application Support` | `~/Library/Application Support/Logria` |
+| Windows | `{FOLDERID_RoamingAppData}` | `%homedrive%%homepath%\AppData\Roaming\Logria` |
+
+If you want to specify a different path, either set `LOGRIA_ROOT` to replace the `/Logria/` directory or set `LOGRIA_USER_HOME` to move the directory away from the default `$HOME`. Setting both means the app looks in `$LOGRIA_USER_HOME/$LOGRIA_ROOT`.
 
 #### Example Exports
 
-| export | value | result |
+| Environment Variable | Value | Result |
 |---|---|---|
-| `LOGRIA_ROOT` | `.config/logria` | `~/.config/logria/` |
-| `LOGRIA_USER_HOME` | `/usr/local/` | `/usr/local/.logria` |
-| both of the above | | `/usr/local/.config/logria/` |
+| `LOGRIA_ROOT` | `.conf/.logria` | `~/.conf/.logria/` |
+| `LOGRIA_USER_HOME` | `/usr/local/` | `/usr/local/Logria` |
+| both of the above | | `/usr/local/.conf/.logria/` |
 
 ## Sample Usage Session
 

--- a/src/constants/directories.rs
+++ b/src/constants/directories.rs
@@ -1,4 +1,7 @@
-use crate::constants::resolver::{get_env_var_or_default, get_home_dir};
+use crate::constants::{
+    app::NAME,
+    resolver::{get_env_var_or_default, get_home_dir},
+};
 
 // Paths
 pub fn home() -> String {
@@ -8,7 +11,7 @@ pub fn home() -> String {
 pub fn app_root() -> String {
     let mut root = home();
     root.push('/');
-    root.push_str(&get_env_var_or_default("LOGRIA_ROOT", ".logria"));
+    root.push_str(&get_env_var_or_default("LOGRIA_ROOT", NAME));
     root
 }
 
@@ -39,45 +42,45 @@ pub fn history_tape() -> String {
 #[cfg(test)]
 mod tests {
     use crate::constants::directories;
-    use dirs::home_dir;
+    use dirs::config_dir;
 
     #[test]
     fn test_app_root() {
         let t = directories::app_root();
-        let mut root = home_dir().expect("").to_str().expect("").to_string();
-        root.push_str("/.logria");
+        let mut root = config_dir().unwrap().to_str().unwrap().to_string();
+        root.push_str("/Logria");
         assert_eq!(t, root)
     }
 
     #[test]
     fn test_patterns() {
         let t = directories::patterns();
-        let mut root = home_dir().expect("").to_str().expect("").to_string();
-        root.push_str("/.logria/patterns");
+        let mut root = config_dir().unwrap().to_str().unwrap().to_string();
+        root.push_str("/Logria/patterns");
         assert_eq!(t, root)
     }
 
     #[test]
     fn test_sessions() {
         let t = directories::sessions();
-        let mut root = home_dir().expect("").to_str().expect("").to_string();
-        root.push_str("/.logria/sessions");
+        let mut root = config_dir().expect("").to_str().expect("").to_string();
+        root.push_str("/Logria/sessions");
         assert_eq!(t, root)
     }
 
     #[test]
     fn test_history() {
         let t = directories::history();
-        let mut root = home_dir().expect("").to_str().expect("").to_string();
-        root.push_str("/.logria/history");
+        let mut root = config_dir().expect("").to_str().expect("").to_string();
+        root.push_str("/Logria/history");
         assert_eq!(t, root)
     }
 
     #[test]
     fn test_history_tape() {
         let t = directories::history_tape();
-        let mut root = home_dir().expect("").to_str().expect("").to_string();
-        root.push_str("/.logria/history/tape");
+        let mut root = config_dir().expect("").to_str().expect("").to_string();
+        root.push_str("/Logria/history/tape");
         assert_eq!(t, root)
     }
 }

--- a/src/constants/resolver.rs
+++ b/src/constants/resolver.rs
@@ -1,10 +1,10 @@
-use dirs::home_dir;
+use dirs::config_dir;
 use std::env;
 
 pub fn get_home_dir() -> String {
     match env::var("LOGRIA_USER_HOME") {
         Ok(val) => val,
-        Err(_) => home_dir()
+        Err(_) => config_dir()
             .expect("Unable to start application: home directory not resolved!")
             .to_str()
             .expect("Home directory path is badly malformed!")


### PR DESCRIPTION
- Use platform-specific `config` directory in lieu of the user's home directory