### PR TITLE
Bugfix/cs/parser scroll bug

### DIFF
--- a/src/communication/handlers/multiple_choice.rs
+++ b/src/communication/handlers/multiple_choice.rs
@@ -100,6 +100,7 @@ impl Handler for MultipleChoiceHandler {
             // User text input
             key => self.input_handler.receive_input(window, key)?,
         }
+        window.redraw()?;
         Ok(())
     }
 }

--- a/src/communication/handlers/regex.rs
+++ b/src/communication/handlers/regex.rs
@@ -161,6 +161,7 @@ impl Handler for RegexHandler {
                 key => self.input_handler.receive_input(window, key)?,
             },
         }
+        window.redraw()?;
         Ok(())
     }
 }

--- a/src/communication/reader.rs
+++ b/src/communication/reader.rs
@@ -442,14 +442,16 @@ pub mod main {
                     message = self.highlight_match(message);
                 }
 
-                // Adding padding and printing over the rest of the line is better than
-                // clearing the screen and writing again. This is because we can only fit
-                // a few items into the render queue. Because the queue is flushed
-                // automatically when it is full, we end up having a lot of partial screen
-                // renders, i.e. a lot of flickering, which makes for bad UX. This is not
-                // a perfect solution because we can still get partial renders if the
-                // terminal has a lot of lines, but we are guaranteed to never have blank
-                // lines in the render, which are what cause the flickering effect.
+                /*
+                Adding padding and printing over the rest of the line is better than
+                clearing the screen and writing again. This is because we can only fit
+                a few items into the render queue. Because the queue is flushed
+                automatically when it is full, we end up having a lot of partial screen
+                renders, i.e. a lot of flickering, which makes for bad UX. This is not
+                a perfect solution because we can still get partial renders if the
+                terminal has a lot of lines, but we are guaranteed to never have blank
+                lines in the render, which are what cause the flickering effect.
+                */
                 let message_padding_size = (width * message_rows) - message_length;
                 let padding = " ".repeat(message_padding_size);
 
@@ -538,7 +540,6 @@ pub mod main {
 
         /// Overwrites the output window with empty space
         /// TODO: faster?
-        ///! Unused currently because it is too slow and causes flickering
         pub fn reset_output(&mut self) -> Result<()> {
             let last_row = self.config.last_row - 1;
             execute!(self.output, cursor::SavePosition)?;

--- a/src/extensions/parser.rs
+++ b/src/extensions/parser.rs
@@ -326,7 +326,9 @@ mod tests {
         let mut map = HashMap::new();
         map.insert(
             String::from("DateTime"),
-            AggregationMethod::DateTime(String::from("[year]-[month]-[day] [hour]:[month]:[second]")),
+            AggregationMethod::DateTime(String::from(
+                "[year]-[month]-[day] [hour]:[month]:[second]",
+            )),
         );
         map.insert(String::from("Method"), AggregationMethod::Count);
         map.insert(String::from("Level"), AggregationMethod::Count);
@@ -334,7 +336,9 @@ mod tests {
         let mut map2 = HashMap::new();
         map2.insert(
             String::from("DateTime"),
-            AggregationMethod::DateTime(String::from("[year]-[month]-[day] [hour]:[month]:[second]")),
+            AggregationMethod::DateTime(String::from(
+                "[year]-[month]-[day] [hour]:[month]:[second]",
+            )),
         );
         map2.insert(String::from("Method"), AggregationMethod::Count);
         map2.insert(String::from("Level"), AggregationMethod::Count);


### PR DESCRIPTION
- Fix off-by-one `Capture` bug with `regex` parsers
- Fix input not updating the screen for static streams
- Resolve `regex_handle` crash when invoking `unwrap()` on the `None` variant of `captures.get()`