### PR TITLE
Feat/cs/more parser tests

### DIFF
--- a/src/communication/handlers/parser.rs
+++ b/src/communication/handlers/parser.rs
@@ -16,7 +16,7 @@ use crate::{
         parser::{Parser, PatternType},
     },
     ui::scroll,
-    util::{ error::LogriaError},
+    util::error::LogriaError,
 };
 
 #[derive(Debug, PartialEq)]
@@ -799,18 +799,8 @@ mod regex_tests {
             ],
             map,
         );
-        parser
-            .aggregator_map
-            .insert(String::from("full"), Box::new(Mean::new()));
-        parser
-            .aggregator_map
-            .insert(String::from("minus_1"), Box::new(Mean::new()));
-        parser
-            .aggregator_map
-            .insert(String::from("minus_2"), Box::new(Mean::new()));
-        parser
-            .aggregator_map
-            .insert(String::from("minus_3"), Box::new(Mean::new()));
+
+        parser.setup();
 
         // Update window config
         handler.parser = Some(parser);
@@ -949,18 +939,8 @@ mod split_tests {
             ],
             map,
         );
-        parser
-            .aggregator_map
-            .insert(String::from("full"), Box::new(Mean::new()));
-        parser
-            .aggregator_map
-            .insert(String::from("minus_1"), Box::new(Mean::new()));
-        parser
-            .aggregator_map
-            .insert(String::from("minus_2"), Box::new(Mean::new()));
-        parser
-            .aggregator_map
-            .insert(String::from("minus_3"), Box::new(Mean::new()));
+
+        parser.setup();
 
         // Update window config
         handler.parser = Some(parser);
@@ -1035,18 +1015,7 @@ mod failure_tests {
             map,
         );
 
-        parser
-            .aggregator_map
-            .insert(String::from("full"), Box::new(Mean::new()));
-        parser
-            .aggregator_map
-            .insert(String::from("minus_1"), Box::new(Mean::new()));
-        parser
-            .aggregator_map
-            .insert(String::from("minus_2"), Box::new(Mean::new()));
-        parser
-            .aggregator_map
-            .insert(String::from("minus_3"), Box::new(Mean::new()));
+        parser.setup();
 
         // Update window config
         handler.parser = Some(parser);

--- a/src/extensions/parser.rs
+++ b/src/extensions/parser.rs
@@ -253,6 +253,8 @@ impl Parser {
 mod parse_tests {
     use std::collections::HashMap;
 
+    use time::parsing::Parsable;
+
     use crate::{
         constants::directories::patterns,
         extensions::{
@@ -623,6 +625,7 @@ mod aggregate_tests {
             map,
         );
         parser.setup();
+        assert!(parser.aggregator_map.get("1").is_some());
     }
 
     #[test]
@@ -640,6 +643,7 @@ mod aggregate_tests {
             map,
         );
         parser.setup();
+        assert!(parser.aggregator_map.get("1").is_some());
     }
 
     #[test]
@@ -659,6 +663,7 @@ mod aggregate_tests {
             map,
         );
         parser.setup();
+        assert!(parser.aggregator_map.get("1").is_some());
     }
 
     #[test]
@@ -673,6 +678,7 @@ mod aggregate_tests {
             map,
         );
         parser.setup();
+        assert!(parser.aggregator_map.get("1").is_some());
     }
 
     #[test]
@@ -687,6 +693,7 @@ mod aggregate_tests {
             map,
         );
         parser.setup();
+        assert!(parser.aggregator_map.get("1").is_some());
     }
 
     #[test]
@@ -701,6 +708,7 @@ mod aggregate_tests {
             map,
         );
         parser.setup();
+        assert!(parser.aggregator_map.get("1").is_some());
     }
 
     #[test]
@@ -715,6 +723,7 @@ mod aggregate_tests {
             map,
         );
         parser.setup();
+        assert!(parser.aggregator_map.get("1").is_some());
     }
 
     #[test]
@@ -729,5 +738,6 @@ mod aggregate_tests {
             map,
         );
         parser.setup();
+        assert!(parser.aggregator_map.get("1").is_some());
     }
 }

--- a/src/extensions/parser.rs
+++ b/src/extensions/parser.rs
@@ -250,7 +250,7 @@ impl Parser {
 }
 
 #[cfg(test)]
-mod tests {
+mod parse_tests {
     use std::collections::HashMap;
 
     use crate::{
@@ -559,9 +559,16 @@ mod tests {
             ]
         );
     }
+}
+
+#[cfg(test)]
+mod aggregate_tests {
+    use std::collections::HashMap;
+
+    use crate::{extensions::parser::{AggregationMethod, Parser, PatternType}, util::aggregators::none::NoneAg};
 
     #[test]
-    fn test_can_setup_aggregation_methods() {
+    fn test_can_setup_multiple_aggregation_methods() {
         let mut map = HashMap::new();
         map.insert(
             String::from("Date"),
@@ -575,7 +582,9 @@ mod tests {
         );
         map.insert(
             String::from("Level"),
-            AggregationMethod::DateTime("[year]-[month]-[day] [hour]:[minute]:[second]".to_string()),
+            AggregationMethod::DateTime(
+                "[year]-[month]-[day] [hour]:[minute]:[second]".to_string(),
+            ),
         );
         map.insert(
             String::from("Level"),
@@ -594,6 +603,129 @@ mod tests {
                 "Level".to_string(),
                 "Message".to_string(),
             ],
+            map,
+        );
+        parser.setup();
+    }
+
+    #[test]
+    fn test_can_setup_date() {
+        let mut map = HashMap::new();
+        map.insert(
+            String::from("1"),
+            AggregationMethod::Date(String::from("[year]-[month]-[day]")),
+        );
+        let mut parser = Parser::new(
+            String::from(" - "),
+            PatternType::Split,
+            String::from(""),
+            vec!["1".to_string()],
+            map,
+        );
+        parser.setup();
+    }
+
+    #[test]
+    fn test_can_setup_time() {
+        let mut map = HashMap::new();
+        map.insert(
+            String::from("1"),
+            AggregationMethod::Time(String::from("[hour]:[minute]:[second]")),
+        );
+        let mut parser = Parser::new(
+            String::from(" - "),
+            PatternType::Split,
+            String::from(""),
+            vec!["1".to_string()],
+            map,
+        );
+        parser.setup();
+    }
+
+    #[test]
+    fn test_can_setup_datetime() {
+        let mut map = HashMap::new();
+        map.insert(
+            String::from("1"),
+            AggregationMethod::DateTime(String::from(
+                "[year]-[month]-[day] [hour]:[minute]:[second]",
+            )),
+        );
+        let mut parser = Parser::new(
+            String::from(" - "),
+            PatternType::Split,
+            String::from(""),
+            vec!["1".to_string()],
+            map,
+        );
+        parser.setup();
+    }
+
+    #[test]
+    fn test_can_setup_count() {
+        let mut map = HashMap::new();
+        map.insert(String::from("1"), AggregationMethod::Count);
+        let mut parser = Parser::new(
+            String::from(" - "),
+            PatternType::Split,
+            String::from(""),
+            vec!["1".to_string()],
+            map,
+        );
+        parser.setup();
+    }
+
+    #[test]
+    fn test_can_setup_mode() {
+        let mut map = HashMap::new();
+        map.insert(String::from("1"), AggregationMethod::Mode);
+        let mut parser = Parser::new(
+            String::from(" - "),
+            PatternType::Split,
+            String::from(""),
+            vec!["1".to_string()],
+            map,
+        );
+        parser.setup();
+    }
+
+    #[test]
+    fn test_can_setup_mean() {
+        let mut map = HashMap::new();
+        map.insert(String::from("1"), AggregationMethod::Mean);
+        let mut parser = Parser::new(
+            String::from(" - "),
+            PatternType::Split,
+            String::from(""),
+            vec!["1".to_string()],
+            map,
+        );
+        parser.setup();
+    }
+
+    #[test]
+    fn test_can_setup_sum() {
+        let mut map = HashMap::new();
+        map.insert(String::from("1"), AggregationMethod::Sum);
+        let mut parser = Parser::new(
+            String::from(" - "),
+            PatternType::Split,
+            String::from(""),
+            vec!["1".to_string()],
+            map,
+        );
+        parser.setup();
+    }
+
+    #[test]
+    fn test_can_setup_none() {
+        let mut map = HashMap::new();
+        map.insert(String::from("1"), AggregationMethod::None);
+        let mut parser = Parser::new(
+            String::from(" - "),
+            PatternType::Split,
+            String::from(""),
+            vec!["1".to_string()],
             map,
         );
         parser.setup();

--- a/src/extensions/parser.rs
+++ b/src/extensions/parser.rs
@@ -253,8 +253,6 @@ impl Parser {
 mod parse_tests {
     use std::collections::HashMap;
 
-    use time::parsing::Parsable;
-
     use crate::{
         constants::directories::patterns,
         extensions::{
@@ -567,7 +565,7 @@ mod parse_tests {
 mod aggregate_tests {
     use std::collections::HashMap;
 
-    use crate::{extensions::parser::{AggregationMethod, Parser, PatternType}, util::aggregators::none::NoneAg};
+    use crate::extensions::parser::{AggregationMethod, Parser, PatternType};
 
     #[test]
     fn test_can_setup_multiple_aggregation_methods() {


### PR DESCRIPTION
- Add parser tests for all aggregation methods
- Use `.setup()` call in unit tests