### PR TITLE
Fix #97

### DIFF
--- a/src/communication/input.rs
+++ b/src/communication/input.rs
@@ -143,6 +143,7 @@ pub mod streams {
                             .current_dir(current_dir().unwrap())
                             .stdout(Stdio::piped())
                             .stderr(Stdio::piped())
+                            .stdin(Stdio::null())
                             .spawn()
                         {
                             Ok(connected) => connected,


### PR DESCRIPTION
- Pipe stdin to null to allow crossterm to retain control to fix #97 